### PR TITLE
Updating oauth2-client version to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "league/oauth2-client": "^1.0"
+        "league/oauth2-client": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Current package can't be used with other packages since this requires an older version of the oauth2 client.