### PR TITLE
NEW Add DigitalOceanAccessToken

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0"

--- a/src/Provider/DigitalOcean.php
+++ b/src/Provider/DigitalOcean.php
@@ -2,10 +2,13 @@
 
 namespace ChrisHemmings\OAuth2\Client\Provider;
 
+use ChrisHemmings\OAuth2\Client\Token\DigitalOceanAccessToken;
+use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
 
@@ -87,5 +90,20 @@ class DigitalOcean extends AbstractProvider
     protected function createResourceOwner(array $response, AccessToken $token)
     {
         return new DigitalOceanResourceOwner($response);
+    }
+
+    /**
+     * Creates an access token from a response.
+     *
+     * The grant that was used to fetch the response can be used to provide
+     * additional context.
+     *
+     * @param  array $response
+     * @param  AbstractGrant $grant
+     * @return AccessTokenInterface
+     */
+    protected function createAccessToken(array $response, AbstractGrant $grant)
+    {
+        return new DigitalOceanAccessToken($response);
     }
 }

--- a/src/Token/DigitalOceanAccessToken.php
+++ b/src/Token/DigitalOceanAccessToken.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ChrisHemmings\OAuth2\Client\Token;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+class DigitalOceanAccessToken extends AccessToken
+{
+    /**
+     * @var string
+     */
+    protected $scope;
+
+    /**
+     * @var array
+     */
+    protected $info;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(array $options = [])
+    {
+        if (!empty($options['scope'])) {
+            $this->scope = $options['scope'];
+        }
+        if (!empty($options['info'])) {
+            $this->info = $options['info'];
+        }
+        parent::__construct($options);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getScopes()
+    {
+        if (empty($this->scope)) {
+            return [];
+        }
+        return array_filter(explode(' ', $this->scope));
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+
+    /**
+     * @param string $scope
+     * @return bool
+     */
+    public function hasScope($scope)
+    {
+        $scope = trim(strtolower($scope));
+        foreach ($this->getScopes() as $candidate) {
+            if ($scope === strtolower(trim($candidate))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize()
+    {
+        $parameters = parent::jsonSerialize();
+
+        if ($this->scope) {
+            $parameters['scope'] = $this->scope;
+        }
+
+        if ($this->info) {
+            $parameters['info'] = $this->info;
+        }
+
+        return $parameters;
+    }
+}

--- a/test/src/Provider/DigitalOceanTest.php
+++ b/test/src/Provider/DigitalOceanTest.php
@@ -3,6 +3,7 @@
 namespace ChrisHemmings\OAuth2\Client\Test\Provider;
 
 use ChrisHemmings\OAuth2\Client\Provider\DigitalOcean;
+use ChrisHemmings\OAuth2\Client\Token\DigitalOceanAccessToken;
 use Mockery as m;
 use ReflectionClass;
 
@@ -65,18 +66,35 @@ class DigitalOceanTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAccessToken()
     {
+        // lifted from DigitalOcean docs
+        $testResponse = [
+            'access_token' => '547cac21118ae7',
+            'token_type' => 'bearer',
+            'expires_in' => 2592000,
+            'refresh_token' => '00a3aae641658d',
+            'scope' => 'read write',
+            'info' => [
+                'name' => 'Sammy the Shark',
+                'email' => 'sammy@digitalocean.com',
+                'uuid' => 'e028b1b918853eca7fba208a9d7e9d29a6e93c57',
+            ],
+        ];
         $response = m::mock('Psr\Http\Message\ResponseInterface');
-        $response->shouldReceive('getBody')->andReturn('{"access_token":"mock_access_token", "token_type":"bearer"}');
+        $response->shouldReceive('getBody')->andReturn(\json_encode($testResponse));
         $response->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $response->shouldReceive('getStatusCode')->andReturn(200);
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
+        /** @var DigitalOceanAccessToken $token */
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
-        $this->assertEquals('mock_access_token', $token->getToken());
-        $this->assertNull($token->getExpires());
-        $this->assertNull($token->getRefreshToken());
-        $this->assertNull($token->getResourceOwnerId());
+        $this->assertEquals($testResponse['access_token'], $token->getToken());
+        $this->assertEquals(time() + $testResponse['expires_in'], $token->getExpires());
+        $this->assertEquals($testResponse['refresh_token'], $token->getRefreshToken());
+        $this->assertTrue($token->hasScope('read'));
+        $this->assertTrue($token->hasScope('write'));
+        $this->assertFalse($token->hasScope('badscope'));
+        $this->assertEquals($testResponse['info'], $token->getInfo());
     }
 
     public function testUserData()


### PR DESCRIPTION
This PR adds a new feature, the `DigitalOceanAccessToken`. This allows the developer to access the custom returned information with the access token, such as checking scopes.

This is useful because the [DigitalOcean docs](https://developers.digitalocean.com/documentation/oauth/#other-considerations) state that if your application requires the ~`read`~`write` scope then it should be verified that the token comes with that scope as the user can change it.

> ...it is recommended that you verify that the scope of the access token grant matches the scope that was originally requested.

This can now be done via: `$accessToken->hasScope('write');`

todo:
- [x] Add tests