### PR TITLE
NEW Extract resource owner id from token response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0"

--- a/src/Provider/DigitalOcean.php
+++ b/src/Provider/DigitalOcean.php
@@ -16,6 +16,8 @@ class DigitalOcean extends AbstractProvider
 {
     use BearerAuthorizationTrait;
 
+    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'info.uuid';
+
     /**
      * Get authorization url to begin OAuth flow
      *

--- a/test/src/Provider/DigitalOceanTest.php
+++ b/test/src/Provider/DigitalOceanTest.php
@@ -94,6 +94,7 @@ class DigitalOceanTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($token->hasScope('read'));
         $this->assertTrue($token->hasScope('write'));
         $this->assertFalse($token->hasScope('badscope'));
+        $this->assertEquals($testResponse['info']['uuid'], $token->getResourceOwnerId());
     }
 
     public function testUserData()


### PR DESCRIPTION
By adding the const `ACCESS_TOKEN_RESOURCE_OWNER_ID` to the Digital Ocean Provider we can easily enable the functionality of `AccessToken::getResourceOwnerId()`.

This seemed like a simple fix so worth adding.

Note this PR depends on #4 (mostly for the test changes)